### PR TITLE
Find defproject form even if it's not on the first line

### DIFF
--- a/plugin/src/leiningen/nvd/deps.clj
+++ b/plugin/src/leiningen/nvd/deps.clj
@@ -38,10 +38,14 @@
 
 (defn- raw-project-attributes []
   (with-open [rdr (PushbackReader. (io/reader "project.clj"))]
-    (->>
-     (read rdr)
-     (drop 3)
-     (apply hash-map))))
+    (let [project-form (->>
+                        (repeatedly #(read rdr))
+                        (filter #(= (first %) 'defproject))
+                        (first))]
+      (->>
+       project-form
+       (drop 3)
+       (apply hash-map)))))
 
 (defn dependency? [elem]
   (and


### PR DESCRIPTION
This plugin currently can't find any dependencies if the `defproject` form is not the first line in the file. Our internal project doesn't work with this plugin because we have some code that runs before the `defproject` form.

This patch allows the dependencies to be read regardless of what line the `defproject` is on.