### PR TITLE
Update raw-project-attributes to use leiningen.core.project/read-raw

### DIFF
--- a/plugin/src/leiningen/nvd/deps.clj
+++ b/plugin/src/leiningen/nvd/deps.clj
@@ -28,7 +28,8 @@
    [clojure.string :as s]
    [clojure.java.io :as io]
    [cemerick.pomegranate.aether :as aether]
-   [leiningen.core.classpath :refer [managed-dependency-hierarchy]]))
+   [leiningen.core.classpath :refer [managed-dependency-hierarchy]]
+   [leiningen.core.project :refer [read-raw]]))
 
 (defn flatten-tree [deps]
   (apply concat
@@ -37,15 +38,7 @@
              (cons dep (lazy-seq (flatten-tree subdeps)))))))
 
 (defn- raw-project-attributes []
-  (with-open [rdr (PushbackReader. (io/reader "project.clj"))]
-    (let [project-form (->>
-                        (repeatedly #(read rdr))
-                        (filter #(= (first %) 'defproject))
-                        (first))]
-      (->>
-       project-form
-       (drop 3)
-       (apply hash-map)))))
+  (read-raw "project.clj"))
 
 (defn dependency? [elem]
   (and


### PR DESCRIPTION
Use built-in `leiningen.core.project/read-raw` fn in the case that a user's `project.clj` is a little more dynamic than the norm. 

Right now `lein-nvd` is unable to read my `project.clj` file, despite it being perfectly readable for other tasks/plugins.

For example: if you define variables above the `defproject` form, that are then referenced within the `#=` reader macro, `(repeatedly (read ...))` is not going to fly.

From my understanding, `read-raw` should return the raw project map, and therefore all dependencies, for all profiles.


