### PR TITLE
Only show dependencies with low or high severity in summary table

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,12 @@ dependencies and passes them to a library called [Dependency-Check](https://gith
 > a given dependency. If found, it will generate a report linking to the
 > associated CVE entries.
 
+**BREAKING CHANGE**: version 1.0 only shows a summary table of packages that
+are demarcated as having a CVSS score greater than zero (i.e any that are
+rated OK, are now not shown by default). Any that are rated low or high severity
+continue to be shown. To revert to pre-1.0 behavior, add `:verbose-summary true`
+to your project [configuration](#configuration-options).
+
 ### Installation
 
 To install globally, add `[lein-nvd "0.6.0"]` into the `:plugins` vector of
@@ -136,6 +142,9 @@ There are some specific settings below which are worthy of a few comments:
 * `:suppression-file` default unset
   - Allows for CVEs to be permanently suppressed.
   - See [DependencyCheck documentation](https://jeremylong.github.io/DependencyCheck/) for the XML file-format.
+* `:verbose-summary` default false
+  - When set to true, the summary table includes a severity determination for all dependencies.
+  - When set to false, the summary table includes only packages that have either low or high severity determination.
 
 ## Building locally
 

--- a/src/nvd/config.clj
+++ b/src/nvd/config.clj
@@ -86,6 +86,7 @@
 (def default-settings
   {:exit-after-check true
    :delete-config? true
+   :verbose-results false
    :nvd {:analyzer {:assembly-enabled false}}})
 
 (defn- deep-merge [a b]

--- a/src/nvd/config.clj
+++ b/src/nvd/config.clj
@@ -86,7 +86,7 @@
 (def default-settings
   {:exit-after-check true
    :delete-config? true
-   :verbose-results false
+   :verbose-summary false
    :nvd {:analyzer {:assembly-enabled false}}})
 
 (defn- deep-merge [a b]

--- a/src/nvd/report.clj
+++ b/src/nvd/report.clj
@@ -72,7 +72,7 @@
 (defn- vulnerabilities [project ^Engine engine]
   (sort-by :dependency
            (for [^Dependency dep (.getDependencies engine)
-                 :when (or (vulnerable? dep) (:verbose-report project))]
+                 :when (or (vulnerable? dep) (:verbose-summary project))]
              {:dependency (.getFileName dep) :status (vuln-status dep)})))
 
 (defn- scores [^Engine engine]
@@ -88,7 +88,10 @@
         highest-score (apply max 0 scores)
         color (-> highest-score severity color)
         severity (-> highest-score severity name s/upper-case)]
-    (table summary)
+
+    (when (or (:verbose-summary project) (pos? (count scores)))
+      (table summary))
+
     (println)
     (print (count scores) "vulnerabilities detected. Severity: ")
     (println (style severity color :bright))

--- a/test/resources/self-test.json
+++ b/test/resources/self-test.json
@@ -6,7 +6,8 @@
   "exit-after-check": false,
   "nvd": {
     "data-directory": "test/resources/",
-    "fail-threshold": 11
+    "fail-threshold": 11,
+    "verbose-summary": true
   },
   "classpath": [
     "~/.m2/repository/org/apache/lucene/lucene-core/4.7.2/lucene-core-4.7.2.jar",


### PR DESCRIPTION
Prior functionality showed all dependencies - those with a zero CVSS score were demarcated OK. With this PR, those are suppressed from the summary table. To revert to previous behaviour, add the `:verbose-summary true` config setting.

Fixes #30 