### PR TITLE
Don't let `ExceptionCollection` hide underlying exception info

### DIFF
--- a/src/nvd/task/check.clj
+++ b/src/nvd/task/check.clj
@@ -28,7 +28,8 @@
    [nvd.report :refer [generate-report print-summary fail-build?]]
    [trptcolin.versioneer.core :refer [get-version]])
   (:import
-   [org.owasp.dependencycheck Engine]))
+   [org.owasp.dependencycheck Engine]
+   [org.owasp.dependencycheck.exception ExceptionCollection]))
 
 (defonce version
   {:nvd-clojure (get-version "rm-hull" "nvd-clojure")
@@ -45,7 +46,12 @@
     (doseq [p (:classpath project)]
       (when (jar? p)
         (.scan engine (absolute-path p))))
-    (.analyzeDependencies engine)
+    (try
+      (.analyzeDependencies engine)
+      (catch ExceptionCollection e
+        (let [exception-info (ex-info (str `ExceptionCollection)
+                                      {:exceptions (.getExceptions e)})]
+          (throw exception-info))))
     project))
 
 (defn conditional-exit [project]


### PR DESCRIPTION
This PR should enable diagnosing issues such as those expressed in https://github.com/rm-hull/lein-nvd/issues/34 .

## Does it work?

Yes.

I added the following to a consumer project:

```
checkouts
└── lein-nvd -> ~/lein-nvd
```

, pointing to my branch, and then ran `lein nvd check`.

The result (which without the checkout would be an opaque `ExceptionCollection`) is now:

```
INFO  o.a.c.j.e.memory.AbstractMemoryCache - Memory Cache dispose called.
{:clojure.main/message
 "Syntax error (ExceptionInfo) compiling at (/private/var/folders/2j/336sh1s13jv80nmvg2y5gyc80000gp/T/form-init279064990053398839.clj:1:124).\norg.owasp.dependencycheck.exception.ExceptionCollection\n",
 :clojure.main/triage
 {:clojure.error/phase :compile-syntax-check,
  :clojure.error/line 1,
  :clojure.error/column 124,
  :clojure.error/source "form-init279064990053398839.clj",
  :clojure.error/path
  "/private/var/folders/2j/336sh1s13jv80nmvg2y5gyc80000gp/T/form-init279064990053398839.clj",
  :clojure.error/class clojure.lang.ExceptionInfo,
  :clojure.error/cause
  "org.owasp.dependencycheck.exception.ExceptionCollection"},
 :clojure.main/trace
 {:via
  [{:type clojure.lang.Compiler$CompilerException,
    :message
    "Syntax error compiling at (/private/var/folders/2j/336sh1s13jv80nmvg2y5gyc80000gp/T/form-init279064990053398839.clj:1:124).",
    :data
    {:clojure.error/phase :compile-syntax-check,
     :clojure.error/line 1,
     :clojure.error/column 124,
     :clojure.error/source
     "/private/var/folders/2j/336sh1s13jv80nmvg2y5gyc80000gp/T/form-init279064990053398839.clj"},
    :at [clojure.lang.Compiler load "Compiler.java" 7648]}
   {:type clojure.lang.ExceptionInfo,
    :message "org.owasp.dependencycheck.exception.ExceptionCollection",
    :data {:exceptions [#error {
 :cause "com.google.common.base.Preconditions.checkState(ZLjava/lang/String;Ljava/lang/Object;)V"
 :via
 [{:type org.owasp.dependencycheck.exception.InitializationException
   :message "Unexpected Exception"
   :at [org.owasp.dependencycheck.Engine initializeAnalyzer "Engine.java" 862]}
  {:type java.lang.NoSuchMethodError
   :message "com.google.common.base.Preconditions.checkState(ZLjava/lang/String;Ljava/lang/Object;)V"
   :at [org.sonatype.ossindex.service.client.cache.DirectoryCache <init> "DirectoryCache.java" 83]}]
 :trace
 [[org.sonatype.ossindex.service.client.cache.DirectoryCache <init> "DirectoryCache.java" 83]
  [org.sonatype.ossindex.service.client.cache.DirectoryCache$Configuration create "DirectoryCache.java" 315]
  [org.sonatype.ossindex.service.client.internal.OssindexClientImpl <init> "OssindexClientImpl.java" 96]
  [org.owasp.dependencycheck.data.ossindex.OssindexClientFactory create "OssindexClientFactory.java" 120]
  [org.owasp.dependencycheck.analyzer.OssIndexAnalyzer prepareAnalyzer "OssIndexAnalyzer.java" 130]
  [org.owasp.dependencycheck.analyzer.AbstractAnalyzer prepare "AbstractAnalyzer.java" 102]
  [org.owasp.dependencycheck.Engine initializeAnalyzer "Engine.java" 842]
  [org.owasp.dependencycheck.Engine analyzeDependencies "Engine.java" 678]
  [nvd.task.check$scan_and_analyze$fn__94495 invoke "check.clj" 50]
  [nvd.task.check$scan_and_analyze invokeStatic "check.clj" 49]
  [nvd.task.check$scan_and_analyze invoke "check.clj" 44]
  [nvd.task.check$_main invokeStatic "check.clj" 69]
  [nvd.task.check$_main invoke "check.clj" 65]
  [user$eval94506 invokeStatic "form-init279064990053398839.clj" 1]
  [user$eval94506 invoke "form-init279064990053398839.clj" 1]
  [clojure.lang.Compiler eval "Compiler.java" 7177]
  [clojure.lang.Compiler eval "Compiler.java" 7167]
  [clojure.lang.Compiler load "Compiler.java" 7636]
  [clojure.lang.Compiler loadFile "Compiler.java" 7574]
  [clojure.main$load_script invokeStatic "main.clj" 475]
  [clojure.main$init_opt invokeStatic "main.clj" 477]
  [clojure.main$init_opt invoke "main.clj" 477]
  [clojure.main$initialize invokeStatic "main.clj" 508]
  [clojure.main$null_opt invokeStatic "main.clj" 542]
  [clojure.main$null_opt invoke "main.clj" 539]
  [clojure.main$main invokeStatic "main.clj" 664]
  [clojure.main$main doInvoke "main.clj" 616]
  [clojure.lang.RestFn applyTo "RestFn.java" 137]
  [clojure.lang.Var applyTo "Var.java" 705]
  [clojure.main main "main.java" 40]]}]},
    :at
    [nvd.task.check$scan_and_analyze$fn__94495
     invoke
     "check.clj"
     55]}],
  :trace
  [[nvd.task.check$scan_and_analyze$fn__94495 invoke "check.clj" 55]
   [nvd.task.check$scan_and_analyze invokeStatic "check.clj" 49]
   [nvd.task.check$scan_and_analyze invoke "check.clj" 44]
   [nvd.task.check$_main invokeStatic "check.clj" 69]
   [nvd.task.check$_main invoke "check.clj" 65]
   [user$eval94506 invokeStatic "form-init279064990053398839.clj" 1]
   [user$eval94506 invoke "form-init279064990053398839.clj" 1]
   [clojure.lang.Compiler eval "Compiler.java" 7177]
   [clojure.lang.Compiler eval "Compiler.java" 7167]
   [clojure.lang.Compiler load "Compiler.java" 7636]
   [clojure.lang.Compiler loadFile "Compiler.java" 7574]
   [clojure.main$load_script invokeStatic "main.clj" 475]
   [clojure.main$init_opt invokeStatic "main.clj" 477]
   [clojure.main$init_opt invoke "main.clj" 477]
   [clojure.main$initialize invokeStatic "main.clj" 508]
   [clojure.main$null_opt invokeStatic "main.clj" 542]
   [clojure.main$null_opt invoke "main.clj" 539]
   [clojure.main$main invokeStatic "main.clj" 664]
   [clojure.main$main doInvoke "main.clj" 616]
   [clojure.lang.RestFn applyTo "RestFn.java" 137]
   [clojure.lang.Var applyTo "Var.java" 705]
   [clojure.main main "main.java" 40]],
  :cause "org.owasp.dependencycheck.exception.ExceptionCollection",
  :data {:exceptions [#error {
 :cause "com.google.common.base.Preconditions.checkState(ZLjava/lang/String;Ljava/lang/Object;)V"
 :via
 [{:type org.owasp.dependencycheck.exception.InitializationException
   :message "Unexpected Exception"
   :at [org.owasp.dependencycheck.Engine initializeAnalyzer "Engine.java" 862]}
  {:type java.lang.NoSuchMethodError
   :message "com.google.common.base.Preconditions.checkState(ZLjava/lang/String;Ljava/lang/Object;)V"
   :at [org.sonatype.ossindex.service.client.cache.DirectoryCache <init> "DirectoryCache.java" 83]}]
 :trace
 [[org.sonatype.ossindex.service.client.cache.DirectoryCache <init> "DirectoryCache.java" 83]
  [org.sonatype.ossindex.service.client.cache.DirectoryCache$Configuration create "DirectoryCache.java" 315]
  [org.sonatype.ossindex.service.client.internal.OssindexClientImpl <init> "OssindexClientImpl.java" 96]
  [org.owasp.dependencycheck.data.ossindex.OssindexClientFactory create "OssindexClientFactory.java" 120]
  [org.owasp.dependencycheck.analyzer.OssIndexAnalyzer prepareAnalyzer "OssIndexAnalyzer.java" 130]
  [org.owasp.dependencycheck.analyzer.AbstractAnalyzer prepare "AbstractAnalyzer.java" 102]
  [org.owasp.dependencycheck.Engine initializeAnalyzer "Engine.java" 842]
  [org.owasp.dependencycheck.Engine analyzeDependencies "Engine.java" 678]
  [nvd.task.check$scan_and_analyze$fn__94495 invoke "check.clj" 50]
  [nvd.task.check$scan_and_analyze invokeStatic "check.clj" 49]
  [nvd.task.check$scan_and_analyze invoke "check.clj" 44]
  [nvd.task.check$_main invokeStatic "check.clj" 69]
  [nvd.task.check$_main invoke "check.clj" 65]
  [user$eval94506 invokeStatic "form-init279064990053398839.clj" 1]
  [user$eval94506 invoke "form-init279064990053398839.clj" 1]
  [clojure.lang.Compiler eval "Compiler.java" 7177]
  [clojure.lang.Compiler eval "Compiler.java" 7167]
  [clojure.lang.Compiler load "Compiler.java" 7636]
  [clojure.lang.Compiler loadFile "Compiler.java" 7574]
  [clojure.main$load_script invokeStatic "main.clj" 475]
  [clojure.main$init_opt invokeStatic "main.clj" 477]
  [clojure.main$init_opt invoke "main.clj" 477]
  [clojure.main$initialize invokeStatic "main.clj" 508]
  [clojure.main$null_opt invokeStatic "main.clj" 542]
  [clojure.main$null_opt invoke "main.clj" 539]
  [clojure.main$main invokeStatic "main.clj" 664]
  [clojure.main$main doInvoke "main.clj" 616]
  [clojure.lang.RestFn applyTo "RestFn.java" 137]
  [clojure.lang.Var applyTo "Var.java" 705]
  [clojure.main main "main.java" 40]]}]},
  :phase :compile-syntax-check}}
```

i.e., now I can see that my actual error is a `java.lang.NoSuchMethodError`.

## QA plan

Run the following:

```clj
(in-ns 'nvd.task.check)

(try
     (throw (doto (ExceptionCollection.)
        (.addException (ex-info "a" {:A :a}))
        (.addException (ex-info "b" {:B :b}))))
     (catch ExceptionCollection e
       (let [exception-info (ex-info (str `ExceptionCollection)
                                     {:exceptions (.getExceptions e)})]
         (throw exception-info))))
```

You should get a detailed stacktrace, including both the "a" and "b" exceptions.