### PR TITLE
Remove eval-in-project

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,12 +43,6 @@ are detected, then the check process will exit abnormally, thereby
 causing any CI build environment to error. (This behaviour can be overriden by
 setting a `:fail-threshold` in the project [configuration](#configuration-options)).
 
-**IMPORTANT NOTE:** By default, the plugin will always use the latest release
-version of nvd. To specify the version of nvd manually, set the `NVD_VERSION`
-environmental variable to desired value, for example:
-
-    NVD_VERSION=1.1.1 lein nvd check
-
 ### Example
 
 There is an [example project](https://github.com/rm-hull/lein-nvd/blob/master/example/project.clj)
@@ -154,10 +148,6 @@ There are some specific settings below which are worthy of a few comments:
 * `:output-dir` default value `target/nvd/`: the directory to save reports into
 
 ## Building locally
-
-The core module is run outside of leiningen (there is a conflict in the version of
-Lucene that is used in the dependency-check libs vs. the version of Lucene that is
-embedded in Leiningen).
 
 Build and install the core module, then do the same for the plugin:
 

--- a/plugin/project.clj
+++ b/plugin/project.clj
@@ -6,7 +6,8 @@
     :url "http://opensource.org/licenses/MIT"}
   :dependencies [
     [org.clojure/data.json "0.2.6"]
-    [com.cemerick/pomegranate "1.1.0"]]
+    [com.cemerick/pomegranate "1.1.0"]
+    [nvd-clojure "1.2.0"]]
   :scm {:url "git@github.com:rm-hull/lein-nvd.git"}
   :source-paths ["src"]
   :jar-exclusions [#"(?:^|/).git"]


### PR DESCRIPTION
These changes cause `nvd` tasks to be run outside the project context, using the plugin classpath rather than the project classpath, in order to avoid dependency conflicts. See #10 and #11 for motivation and discussion.

I stumbled into this while attempting to use `lein-nvd` in a project that also depends on (an earlier major version of) Lucene, resulting in the same sort of breakage that prompted `lein-nvd` to resort to `eval-in-project` in the first place.

This is a breaking change in the sense that the latest `nvd-clojure` is no longer dynamically retrieved. As a corollary, the `NVD_VERSION` environment variable can no longer be used to pin to a specific version.

The above capability could possibly be restored via `cemerick.pomegranate/add-dependencies`, but that seems likely to lead to more conflicts with leiningen dependencies, and I have not attempted it.