### PR TITLE
Fix output typo

### DIFF
--- a/src/nvd/task/check.clj
+++ b/src/nvd/task/check.clj
@@ -62,7 +62,7 @@
 (defn -main [config-file]
   (with-config [project config-file]
     (println "Checking dependencies for" (style (:title project) :bright :yellow) "...")
-    (println "  using nvd-clojure:" (:nvd-clojure version) "and depdendency-check:" (:dependency-check version))
+    (println "  using nvd-clojure:" (:nvd-clojure version) "and dependency-check:" (:dependency-check version))
     (-> project
         scan-and-analyze
         generate-report


### PR DESCRIPTION
Just a small typo in the output of `nvd check`