### PR TITLE
nvd.task.check/-main without arguments runs report with deps.edn class-path

### DIFF
--- a/src/nvd/task/check.clj
+++ b/src/nvd/task/check.clj
@@ -61,7 +61,6 @@
 
 (defn make-classpath []
   (let [paths (.getURLs (ClassLoader/getSystemClassLoader))]
-    ;;(vec (map #(.getFile %) paths))
     (apply print-str (map #(str "\"" (.getFile %) "\",") paths))))
 
 (defn -main [& config-file]


### PR DESCRIPTION
Hi,
i took liberty to decorate nvd.task.check/-main with if-some statement s.t. if -main is called without arguments it uses own classpath. this allows running nvd-clojure with clojure cli like so
clj -Sdeps '{:extra-deps {nvd-clojure {:mvn/version "1.3.2"}}}' -m nvd.task.check

Happy New Year

edit: needed curly brace at the end