### PR TITLE
bump dependency-check-core to 5.3.2

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -9,7 +9,7 @@
     [clansi "1.0.0"]
     [org.clojure/data.json "1.0.0"]
     [org.slf4j/slf4j-simple "1.7.29"]
-    [org.owasp/dependency-check-core "5.2.4"]
+    [org.owasp/dependency-check-core "5.3.2"]
     [rm-hull/table "0.7.1"]
     [trptcolin/versioneer "0.2.0"]]
   :scm {:url "git@github.com:rm-hull/lein-nvd.git"}

--- a/test/nvd/config_test.clj
+++ b/test/nvd/config_test.clj
@@ -26,7 +26,7 @@
    [clojure.test :refer :all]
    [nvd.config :refer :all]))
 
-(def dependency-check-version "5.2.4")
+(def dependency-check-version "5.3.2")
 
 (deftest check-app-name
   (is (= "unknown" (app-name {:nome "hello-world" :version "0.0.1"})))


### PR DESCRIPTION
Bunch of changes and mostly good stuff:

https://github.com/jeremylong/DependencyCheck/compare/v5.2.4...v5.3.2

Mostly because of this one commit that makes detection more reliable for some libraries with names matching other (unrelated, non-Maven) libraries and returning false positives: https://github.com/jeremylong/DependencyCheck/commit/585d560c7c2e24ea4e9eb190024abab8de85ee79