### PR TITLE
Better Error Printing for Exceptions Thrown During Analysis

### DIFF
--- a/src/nvd/task/check.clj
+++ b/src/nvd/task/check.clj
@@ -49,6 +49,9 @@
     (try
       (.analyzeDependencies engine)
       (catch ExceptionCollection e
+        (println "Encountered errors while analyzing:" (.getMessage e))
+        (doseq [exc (.getExceptions e)]
+          (println exc))
         (let [exception-info (ex-info (str `ExceptionCollection)
                                       {:exceptions (.getExceptions e)})]
           (throw exception-info))))


### PR DESCRIPTION
Previously, only an unhelpful stacktrace pointing to the re-throw location was printed out whenever execution failed due to an ExceptionCollection being thrown.

This addition prints out the actual contents of the ExceptionCollection, making it much easier to diagnose what caused the failure.

Example before the change:
~~~
~/foobar $ lein nvd check
Checking dependencies for foobar 1.0.0-SNAPSHOT ...
  using nvd-clojure:  and dependency-check: 5.3.2
clojure.lang.ExceptionInfo: org.owasp.dependencycheck.exception.ExceptionCollection
 at clojure.core$ex_info.invokeStatic (core.clj:4617)
    clojure.core$ex_info.invoke (core.clj:4617)
    nvd.task.check$scan_and_analyze$fn__1034.invoke (check.clj:55)
    nvd.task.check$scan_and_analyze.invokeStatic (check.clj:49)
    nvd.task.check$scan_and_analyze.invoke (check.clj:44)
    nvd.task.check$_main.invokeStatic (check.clj:74)
    nvd.task.check$_main.doInvoke (check.clj:69)
    clojure.lang.RestFn.invoke (RestFn.java:408)
    leiningen.nvd$nvd.invokeStatic (nvd.clj:70)
    leiningen.nvd$nvd.doInvoke (nvd.clj:35)
    clojure.lang.RestFn.invoke (RestFn.java:425)
    clojure.lang.Var.invoke (Var.java:383)
    clojure.lang.AFn.applyToHelper (AFn.java:156)
    clojure.lang.Var.applyTo (Var.java:700)
    clojure.core$apply.invokeStatic (core.clj:648)
    clojure.core$apply.invoke (core.clj:641)
    leiningen.core.main$partial_task$fn__4687.doInvoke (main.clj:284)
    clojure.lang.RestFn.applyTo (RestFn.java:139)
    clojure.lang.AFunction$1.doInvoke (AFunction.java:29)
    clojure.lang.RestFn.applyTo (RestFn.java:137)
    clojure.core$apply.invokeStatic (core.clj:648)
    clojure.core$apply.invoke (core.clj:641)
    leiningen.core.main$apply_task.invokeStatic (main.clj:334)
    leiningen.core.main$apply_task.invoke (main.clj:320)
    leiningen.core.main$resolve_and_apply.invokeStatic (main.clj:340)
    leiningen.core.main$resolve_and_apply.invoke (main.clj:336)
    leiningen.core.main$_main$fn__4760.invoke (main.clj:449)
    leiningen.core.main$_main.invokeStatic (main.clj:439)
    leiningen.core.main$_main.doInvoke (main.clj:436)
    clojure.lang.RestFn.invoke (RestFn.java:421)
    clojure.lang.Var.invoke (Var.java:383)
    clojure.lang.AFn.applyToHelper (AFn.java:156)
    clojure.lang.Var.applyTo (Var.java:700)
    clojure.core$apply.invokeStatic (core.clj:646)
    clojure.main$main_opt.invokeStatic (main.clj:314)
    clojure.main$main_opt.invoke (main.clj:310)
    clojure.main$main.invokeStatic (main.clj:421)
    clojure.main$main.doInvoke (main.clj:384)
    clojure.lang.RestFn.invoke (RestFn.java:457)
    clojure.lang.Var.invoke (Var.java:394)
    clojure.lang.AFn.applyToHelper (AFn.java:165)
    clojure.lang.Var.applyTo (Var.java:700)
    clojure.main.main (main.java:37)
~~~

Example after the change:
~~~
~/foobar $ lein nvd check
Checking dependencies for foobar 1.0.0-SNAPSHOT ...
  using nvd-clojure:  and dependency-check: 5.3.2
Encountered errors while analyzing:
#error {
 :cause A JSONObject text must begin with '{' at 0 [character 1 line 1]
 :via
 [{:type org.owasp.dependencycheck.exception.InitializationException
   :message Failed to initialize the RetireJS repo: `/home/thobbs/.m2/repository/org/owasp/dependency-check-utils/5.3.2/data/jsrepository.json` appears to be malformed. Please delete the file or run the dependency-check purge command and re-try running dependency-check.
   :at [org.owasp.dependencycheck.analyzer.RetireJsAnalyzer prepareFileTypeAnalyzer RetireJsAnalyzer.java 204]}
  {:type org.json.JSONException
   :message A JSONObject text must begin with '{' at 0 [character 1 line 1]
   :at [org.json.JSONTokener syntaxError JSONTokener.java 507]}]
 :trace
 [[org.json.JSONTokener syntaxError JSONTokener.java 507]
  [org.json.JSONObject <init> JSONObject.java 222]
  [org.json.JSONObject <init> JSONObject.java 406]
  [com.h3xstream.retirejs.repo.VulnerabilitiesRepositoryLoader loadFromInputStream VulnerabilitiesRepositoryLoader.java 106]
  [org.owasp.dependencycheck.analyzer.RetireJsAnalyzer prepareFileTypeAnalyzer RetireJsAnalyzer.java 201]
  [org.owasp.dependencycheck.analyzer.AbstractFileTypeAnalyzer prepareAnalyzer AbstractFileTypeAnalyzer.java 83]
  [org.owasp.dependencycheck.analyzer.AbstractAnalyzer prepare AbstractAnalyzer.java 102]
  [org.owasp.dependencycheck.Engine initializeAnalyzer Engine.java 856]
  [org.owasp.dependencycheck.Engine analyzeDependencies Engine.java 692]
  [nvd.task.check$scan_and_analyze$fn__1034 invoke check.clj 50]
  [nvd.task.check$scan_and_analyze invokeStatic check.clj 49]
  [nvd.task.check$scan_and_analyze invoke check.clj 44]
  [nvd.task.check$_main invokeStatic check.clj 74]
  [nvd.task.check$_main doInvoke check.clj 69]
  [clojure.lang.RestFn invoke RestFn.java 408]
  [leiningen.nvd$nvd invokeStatic nvd.clj 70]
  [leiningen.nvd$nvd doInvoke nvd.clj 35]
  [clojure.lang.RestFn invoke RestFn.java 425]
  [clojure.lang.Var invoke Var.java 383]
  [clojure.lang.AFn applyToHelper AFn.java 156]
  [clojure.lang.Var applyTo Var.java 700]
  [clojure.core$apply invokeStatic core.clj 648]
  [clojure.core$apply invoke core.clj 641]
  [leiningen.core.main$partial_task$fn__4687 doInvoke main.clj 284]
  [clojure.lang.RestFn applyTo RestFn.java 139]
  [clojure.lang.AFunction$1 doInvoke AFunction.java 29]
  [clojure.lang.RestFn applyTo RestFn.java 137]
  [clojure.core$apply invokeStatic core.clj 648]
  [clojure.core$apply invoke core.clj 641]
  [leiningen.core.main$apply_task invokeStatic main.clj 334]
  [leiningen.core.main$apply_task invoke main.clj 320]
  [leiningen.core.main$resolve_and_apply invokeStatic main.clj 340]
  [leiningen.core.main$resolve_and_apply invoke main.clj 336]
  [leiningen.core.main$_main$fn__4760 invoke main.clj 449]
  [leiningen.core.main$_main invokeStatic main.clj 439]
  [leiningen.core.main$_main doInvoke main.clj 436]
  [clojure.lang.RestFn invoke RestFn.java 421]
  [clojure.lang.Var invoke Var.java 383]
  [clojure.lang.AFn applyToHelper AFn.java 156]
  [clojure.lang.Var applyTo Var.java 700]
  [clojure.core$apply invokeStatic core.clj 646]
  [clojure.main$main_opt invokeStatic main.clj 314]
  [clojure.main$main_opt invoke main.clj 310]
  [clojure.main$main invokeStatic main.clj 421]
  [clojure.main$main doInvoke main.clj 384]
  [clojure.lang.RestFn invoke RestFn.java 457]
  [clojure.lang.Var invoke Var.java 394]
  [clojure.lang.AFn applyToHelper AFn.java 165]
  [clojure.lang.Var applyTo Var.java 700]
  [clojure.main main main.java 37]]}
clojure.lang.ExceptionInfo: org.owasp.dependencycheck.exception.ExceptionCollection
 at clojure.core$ex_info.invokeStatic (core.clj:4617)
    clojure.core$ex_info.invoke (core.clj:4617)
    nvd.task.check$scan_and_analyze$fn__1034.invoke (check.clj:55)
    nvd.task.check$scan_and_analyze.invokeStatic (check.clj:49)
    nvd.task.check$scan_and_analyze.invoke (check.clj:44)
    nvd.task.check$_main.invokeStatic (check.clj:74)
    nvd.task.check$_main.doInvoke (check.clj:69)
    clojure.lang.RestFn.invoke (RestFn.java:408)
    leiningen.nvd$nvd.invokeStatic (nvd.clj:70)
    leiningen.nvd$nvd.doInvoke (nvd.clj:35)
    clojure.lang.RestFn.invoke (RestFn.java:425)
    clojure.lang.Var.invoke (Var.java:383)
    clojure.lang.AFn.applyToHelper (AFn.java:156)
    clojure.lang.Var.applyTo (Var.java:700)
    clojure.core$apply.invokeStatic (core.clj:648)
    clojure.core$apply.invoke (core.clj:641)
    leiningen.core.main$partial_task$fn__4687.doInvoke (main.clj:284)
    clojure.lang.RestFn.applyTo (RestFn.java:139)
    clojure.lang.AFunction$1.doInvoke (AFunction.java:29)
    clojure.lang.RestFn.applyTo (RestFn.java:137)
    clojure.core$apply.invokeStatic (core.clj:648)
    clojure.core$apply.invoke (core.clj:641)
    leiningen.core.main$apply_task.invokeStatic (main.clj:334)
    leiningen.core.main$apply_task.invoke (main.clj:320)
    leiningen.core.main$resolve_and_apply.invokeStatic (main.clj:340)
    leiningen.core.main$resolve_and_apply.invoke (main.clj:336)
    leiningen.core.main$_main$fn__4760.invoke (main.clj:449)
    leiningen.core.main$_main.invokeStatic (main.clj:439)
    leiningen.core.main$_main.doInvoke (main.clj:436)
    clojure.lang.RestFn.invoke (RestFn.java:421)
    clojure.lang.Var.invoke (Var.java:383)
    clojure.lang.AFn.applyToHelper (AFn.java:156)
    clojure.lang.Var.applyTo (Var.java:700)
    clojure.core$apply.invokeStatic (core.clj:646)
    clojure.main$main_opt.invokeStatic (main.clj:314)
    clojure.main$main_opt.invoke (main.clj:310)
    clojure.main$main.invokeStatic (main.clj:421)
    clojure.main$main.doInvoke (main.clj:384)
    clojure.lang.RestFn.invoke (RestFn.java:457)
    clojure.lang.Var.invoke (Var.java:394)
    clojure.lang.AFn.applyToHelper (AFn.java:165)
    clojure.lang.Var.applyTo (Var.java:700)
    clojure.main.main (main.java:37)
~~~