### PR TITLE
Remove redundant (and conflicting) plugin dep

### DIFF
--- a/plugin/project.clj
+++ b/plugin/project.clj
@@ -5,7 +5,6 @@
     :name "The MIT License (MIT)"
     :url "http://opensource.org/licenses/MIT"}
   :dependencies [
-    [org.clojure/data.json "0.2.6"]
     [com.cemerick/pomegranate "1.1.0"]
     [nvd-clojure "1.4.0"]]
   :scm {:url "git@github.com:rm-hull/lein-nvd.git"}


### PR DESCRIPTION
nvd-clojure already depends on data.json 1.0.0. There's no need for the
plugin to separately depend on data.json. Furthermore, the plugin was
depending on 0.2.6, which conflicts with the 1.0.0 dependency.

Fixes #52