### PR TITLE
Adds missing quotes for plugin

### DIFF
--- a/example/project.clj
+++ b/example/project.clj
@@ -25,4 +25,4 @@
       :dependencies [
         [org.clojure/clojure "1.9.0"]]
       :plugins [
-        [lein-nvd "1.4.1]]}})
+        [lein-nvd "1.4.1"]]}})


### PR DESCRIPTION
Project.clj was invalid as the closing double quotes were missing