### PR TITLE
Enable the library to work with > Java 9

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -11,7 +11,8 @@
     [org.slf4j/slf4j-simple "1.7.29"]
     [org.owasp/dependency-check-core "5.3.2"]
     [rm-hull/table "0.7.1"]
-    [trptcolin/versioneer "0.2.0"]]
+    [trptcolin/versioneer "0.2.0"]
+    [org.clojure/java.classpath "1.0.0"]]
   :scm {:url "git@github.com:rm-hull/lein-nvd.git"}
   :source-paths ["src"]
   :jar-exclusions [#"(?:^|/).git"]


### PR DESCRIPTION
Thank you for this library.

There was one issue, when running it under Java that is 8+, the way the classpath is worked out for a project:

```clojure
(.getURLs (ClassLoader/getSystemClassLoader))
```

has changed and would throw an exception with > Java 8.

This PR is my fix for it. Please consider it.

