### PR TITLE
Pass the main for Clojure CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,8 @@ under `:aliases` in _~/.clojure/deps.edn_, or add it to `:aliases` in
 the project local `deps.edn`, to look something like this:
 
 ```clojure
-:aliases {:nvd {:extra-deps {lein-nvd/lein-nvd {:mvn/version "1.4.1"}}}}
+:aliases {:nvd {:extra-deps {lein-nvd/lein-nvd {:mvn/version "1.4.1"}}
+                :main-opts ["-m" "nvd.task.check"]}}
 ```
 
 #### Leiningen


### PR DESCRIPTION
Hi @rm-hull 

I was a bit hasty with the previous PR and I forgot to add the :main-opts.

It would've been nicer if this change went in with the previous commit.

Can you please merge this in? Thanks