### PR TITLE
Added GitHub Action CI run

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,0 +1,26 @@
+name: Continuous Integration
+on: [push, pull_request]
+jobs:
+  ci:
+    name: Linting and tests
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/setup-java@v1
+        with:
+          java-version: '11'
+      - name: Checkout the branch
+        uses: actions/checkout@master
+        with:
+          ref: ${{ github.ref }}
+      - name: eclint
+        uses: snow-actions/eclint@v1.0.1
+        with:
+          args: 'check .* * src/**/*.clj test/**/*.clj'
+      - name: Install leiningen
+        uses: DeLaGuardo/setup-clojure@master
+        with:
+          lein: 2.9.4
+      - run: lein cljfmt check
+      - run: lein with-profile +dev cloverage --coveralls
+      - run: curl -F 'json_file=@target/coverage/coveralls.json' 'https://coveralls.io/api/v1/jobs'
+        if: success()


### PR DESCRIPTION
Hello @rm-hull 

As discussed in #56, I've created the GitHub Actions CI run for the project.

I replaced the TravisCI integration with GitHub Actions, because
TravisCI is stopping to offer free minutes to open source projects.

The only thing that is missing is that the output of the test run is not being POST-ed to coveralls.
I'm not sure what is required, I'm guessing some auth flow... But here it is for now, tell me what you think

https://github.com/dotemacs/lein-nvd/runs/1615066071?check_suite_focus=true

I guess before this can be merged, `.travis.yml` should be removed also.
But it's better to show you this as is, to get some feedback.

Thanks
