### PR TITLE
Add GitHub Action CI outcome badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # lein-nvd
-[![Build Status](https://travis-ci.org/rm-hull/lein-nvd.svg?branch=master)](http://travis-ci.org/rm-hull/lein-nvd)
+[![Build Status](https://github.com/rm-hull/workflows/Continuous%20Integration/badge.svg)](https://github.com/rm-hull/lein-nvd/actions?query=workflow%3A%22Continuous+Integration%22)
 [![Coverage Status](https://coveralls.io/repos/rm-hull/lein-nvd/badge.svg?branch=master)](https://coveralls.io/r/rm-hull/lein-nvd?branch=master)
 [![Dependencies Status](https://versions.deps.co/rm-hull/lein-nvd/status.svg)](https://versions.deps.co/rm-hull/lein-nvd)
 [![Downloads](https://versions.deps.co/rm-hull/lein-nvd/downloads.svg)](https://versions.deps.co/rm-hull/lein-nvd)


### PR DESCRIPTION
Hey @rm-hull 

I forgot to add add this last night. It replaces the TravisCI badge with the GitHub Actions badge in the README.

Thanks

