### PR TITLE
Derive the classpath for Clojure CLI from deps.edn

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -1,0 +1,17 @@
+{:paths ["src"]
+ :deps {org.clojure/clojure {:mvn/version "1.10.1"}
+        org.clojure/java.classpath {:mvn/version "1.0.0"}
+        clansi/clansi {:mvn/version "1.0.0"}
+        org.clojure/data.json {:mvn/version "1.0.0"}
+        org.slf4j/slf4j-simple {:mvn/version "1.7.29"}
+        org.owasp/dependency-check-core {:mvn/version "5.3.2"}
+        rm-hull/table {:mvn/version "0.7.1"}
+        trptcolin/versioneer {:mvn/version "0.2.0"}
+        org.clojure/tools.deps.alpha {:mvn/version "0.9.857"}}
+ :mvn/repos {"central" {:url "https://repo1.maven.org/maven2/"}
+             "clojars" {:url "https://repo.clojars.org/"}}
+ :aliases {:test {:extra-paths ["test"]}
+           :runner {:extra-deps {com.cognitect/test-runner
+                                 {:git/url "https://github.com/cognitect-labs/test-runner"
+                                  :sha "76568540e7f40268ad2b646110f237a60295fa3c"}}
+                    :main-opts ["-m" "cognitect.test-runner" "-d" "test"]}}}

--- a/project.clj
+++ b/project.clj
@@ -4,15 +4,15 @@
   :license {
     :name "The MIT License (MIT)"
     :url "http://opensource.org/licenses/MIT"}
-  :dependencies [
-    [org.clojure/clojure "1.10.1"]
-    [clansi "1.0.0"]
-    [org.clojure/data.json "1.0.0"]
-    [org.slf4j/slf4j-simple "1.7.29"]
-    [org.owasp/dependency-check-core "5.3.2"]
-    [rm-hull/table "0.7.1"]
-    [trptcolin/versioneer "0.2.0"]
-    [org.clojure/java.classpath "1.0.0"]]
+  :dependencies [[org.clojure/clojure "1.10.1"]
+                 [clansi "1.0.0"]
+                 [org.clojure/data.json "1.0.0"]
+                 [org.slf4j/slf4j-simple "1.7.29"]
+                 [org.owasp/dependency-check-core "5.3.2"]
+                 [rm-hull/table "0.7.1"]
+                 [trptcolin/versioneer "0.2.0"]
+                 [org.clojure/java.classpath "1.0.0"]
+                 [org.clojure/tools.deps.alpha "0.9.857"]]
   :scm {:url "git@github.com:rm-hull/lein-nvd.git"}
   :source-paths ["src"]
   :jar-exclusions [#"(?:^|/).git"]

--- a/test/nvd/task/check_test.clj
+++ b/test/nvd/task/check_test.clj
@@ -47,3 +47,7 @@
     (is (== 7.5 (get-in project [:nvd :highest-score])))
     (is (false? (project :failed?)))))
 
+(deftest classpath-test
+  (let [clojure "clojure-1.10.1.jar"]
+    (is (true? (.contains (check/clojure-cli-classpath) clojure)))
+    (is (true? (.contains (check/make-classpath) clojure)))))


### PR DESCRIPTION
The classpath generation in Clojure CLI differs to classpath
generation with Leiningen: with Clojure CLI even the JARs needed for
lein-nvd would be picked up and added to the classpath. Which isn't
what you want when checking your own project/library. To work around
that, the classpath for Clojure CLI is built with just the artifacts
specified in deps.edn.

The assumption is made that if a library/project contains deps.edn,
only that will be read to work the classpath. I'm mentioning this in
the context of projects which have both, deps.edn and project.clj
included in them.

This PR resolves https://github.com/rm-hull/lein-nvd/issues/64