### PR TITLE
Automated dependency management

### DIFF
--- a/.github/workflows/dependencies.yaml
+++ b/.github/workflows/dependencies.yaml
@@ -1,0 +1,61 @@
+name: dependencies
+on:
+  schedule:
+    - cron: "29 7 * * *"
+  workflow_dispatch:
+
+jobs:
+  dependencies:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+      - uses: actions/setup-java@v1
+        with:
+          java-version: '11'
+      - name: Install Clojure CLI
+        uses: DeLaGuardo/setup-clojure@master
+        with:
+          cli: '1.10.1.763'
+          lein: 2.9.5
+      - name: check for outdated dependencies
+        id: deps
+        run: |
+          echo 'Scheduled outdated dependency check:' >> outdated.md
+          echo '```clojure' >> outdated.md
+          clojure -M:outdated >> outdated.md
+          echo '```' >> outdated.md
+          cat outdated.md
+          if [ $(grep -c ':mvn/version' outdated.md) -gt 0 ]; then echo ::set-output name=status::failure; else echo ::set-output name=status::success; fi
+      - if: ${{ steps.deps.outputs.status == 'failure' }}
+        name: Badge
+        uses: RubbaBoy/BYOB@v1.2.0
+        with:
+          NAME: dependencies
+          LABEL: 'dependencies'
+          STATUS: "out of date"
+          COLOR: red
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - if: ${{ steps.deps.outputs.status == 'success' }}
+        name: Badge
+        uses: RubbaBoy/BYOB@v1.2.0
+        with:
+          NAME: dependencies
+          LABEL: 'dependencies'
+          STATUS: 'up to date'
+          COLOR: green
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - if: ${{ steps.deps.outputs.status == 'failure' }}
+        name: Update stale dependencies
+        run: |
+          clojure -M:outdated --write
+          lein ancient upgrade
+      - name: Create Pull Request
+        uses: peter-evans/create-pull-request@v3
+        with:
+          commit-message: Updating stale dependencies
+          title: Update stale dependencies
+          body: Updating dependencies to the latest stable versions
+          branch: update-dependencies
+          base: master

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # lein-nvd
 [![Build Status](https://github.com/rm-hull/lein-nvd/workflows/Continuous%20Integration/badge.svg)](https://github.com/rm-hull/lein-nvd/actions?query=workflow%3A%22Continuous+Integration%22)
 [![Coverage Status](https://coveralls.io/repos/rm-hull/lein-nvd/badge.svg?branch=master)](https://coveralls.io/r/rm-hull/lein-nvd?branch=master)
-[![Dependencies Status](https://versions.deps.co/rm-hull/lein-nvd/status.svg)](https://versions.deps.co/rm-hull/lein-nvd)
+[![Dependencies Status](https://byob.yarr.is/dotemacs/actions-play/dependencies)](https://github.com/rm-hull/lein-nvd/actions?query=workflow%3A%22dependencies%22)
 [![Downloads](https://versions.deps.co/rm-hull/lein-nvd/downloads.svg)](https://versions.deps.co/rm-hull/lein-nvd)
 [![Clojars Project](https://img.shields.io/clojars/v/lein-nvd.svg)](https://clojars.org/lein-nvd)
 [![Maintenance](https://img.shields.io/maintenance/yes/2020.svg?maxAge=2592000)]()

--- a/project.clj
+++ b/project.clj
@@ -27,6 +27,7 @@
       :plugins [
         [lein-cljfmt "0.7.0"]
         [lein-codox "0.10.7"]
-        [lein-cloverage "1.2.1"]]
+        [lein-cloverage "1.2.1"]
+        [lein-ancient "0.6.15"]]
       :dependencies [
         [commons-collections "3.2.1"]]}})


### PR DESCRIPTION
I've taken the liberty to implement automated dependency management.

Why?

The badge pointing to dependency versioning service, does not work.

But even if it did, wouldn't it be more convenient to have something
that let's you know that dependencies not up to date? And what more
convenient than an automated CI job that does just that?

I took the liberty of creating just that workflow. It does the
following:

- it checks for out of date dependencies
- if there are any, updates the badge
- but it also creates the PR with the updated dependencies

And since I've added deps.edn and the project uses Leiningen, I
thought that it would be convenient to automate the updating of both
deps.edn and project.clj with the outdated dependencies.