### PR TITLE
Fix for dependency checking workflow

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,4 @@ test/resources/jsrepository.json
 *.iml
 cache/
 oss_cache/
+.cpcache/

--- a/deps.edn
+++ b/deps.edn
@@ -14,4 +14,6 @@
            :runner {:extra-deps {com.cognitect/test-runner
                                  {:git/url "https://github.com/cognitect-labs/test-runner"
                                   :sha "76568540e7f40268ad2b646110f237a60295fa3c"}}
-                    :main-opts ["-m" "cognitect.test-runner" "-d" "test"]}}}
+                    :main-opts ["-m" "cognitect.test-runner" "-d" "test"]}
+           :outdated {:replace-deps {olical/depot {:mvn/version "2.1.0"}}
+                      :main-opts ["-m" "depot.outdated.main"]}}}


### PR DESCRIPTION
The reason the workflow didn't work (https://github.com/rm-hull/lein-nvd/pull/68) is because no alias for :outdated
was added.

Added .cpcache/ to .gitignore list because it'll be touched every time
an updated of dependencies is performed.