### PR TITLE
Update dependencies in project.clj

### DIFF
--- a/.github/workflows/dependencies.yaml
+++ b/.github/workflows/dependencies.yaml
@@ -28,6 +28,7 @@ jobs:
           echo '```' >> outdated.md
           cat outdated.md
           if [ $(grep -c ':mvn/version' outdated.md) -gt 0 ]; then echo ::set-output name=status::failure; else echo ::set-output name=status::success; fi
+          rm outdated.md
       - if: ${{ steps.deps.outputs.status == 'failure' }}
         name: Badge
         uses: RubbaBoy/BYOB@v1.2.0
@@ -50,7 +51,7 @@ jobs:
         name: Update stale dependencies
         run: |
           clojure -M:outdated --write
-          lein ancient upgrade
+          lein ancient upgrade :no-tests
       - name: Create Pull Request
         uses: peter-evans/create-pull-request@v3
         with:


### PR DESCRIPTION
`outdated.md` needs to be removed before creating the PR otherwise it
makes it into the PR.

`:no-tests` directive needs to be used with lein ancient, so that the
test aren't run straight away, after the dependency upgrade. This way
the PR is created.

Whoever gets the PR will still need to do some manual clean up, but at
least the start of the PR is there and it's visible that the upgrade
should take place.