### PR TITLE
README: elaborate on classpath isolation technique

### DIFF
--- a/.github/integration_test.sh
+++ b/.github/integration_test.sh
@@ -38,6 +38,25 @@ if ! grep --silent "[1-9][0-9] vulnerabilities detected\. Severity: " example-le
   exit 1
 fi
 
+# 3.- Exercise `tools.deps` integration
+
+cd example || exit 1
+
+example_classpath="$(clojure -Spath)"
+
+# cd to the root dir, so that one runs `defproject nvd-clojure` which is the most clean and realistic way to run `main`:
+cd .. || exit 1
+
+if clojure -m nvd.task.check "" "$example_classpath" > example-lein-output; then
+  echo "Should have failed with non-zero code!"
+  exit 1
+fi
+
+if ! grep --silent "[1-9][0-9] vulnerabilities detected\. Severity: " example-lein-output; then
+  echo "Should have found vulnerabilities!"
+  exit 1
+fi
+
 cd "$original" || exit 1
 
 exit 0

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -49,5 +49,6 @@ jobs:
         uses: DeLaGuardo/setup-clojure@master
         with:
           lein: 2.9.4
+          cli: 1.10.1.693
       - run: shellcheck .github/integration_test.sh
       - run: .github/integration_test.sh

--- a/README.md
+++ b/README.md
@@ -182,6 +182,8 @@ clojure -m nvd.task.check "" "$(clojure -Spath)"
 
 ...in both cases, an empty string is passed as the first argument, for backwards compatibility reasons.
 
+For extra isolation, it is recommended that you invoke `nvd.task.check` from _outside_ your project - e.g. from an empty project, a git clone of this very repo, or from $HOME (assuming you have lein-nvd as a dependency in your [user-wide Lein profile](https://github.com/technomancy/leiningen/blob/2586957f9d099ff11d50d312a6daf397c2a06fb1/doc/PROFILES.md)).
+
 ## Building locally
 
 Build and install the core module, then do the same for the plugin:

--- a/example/deps.edn
+++ b/example/deps.edn
@@ -1,0 +1,15 @@
+{:deps      {;;  No known vulnerabilities, but have dependencies
+             org.clojure/data.json                          {:mvn/version "0.2.6"}
+             korma                                          {:mvn/version "0.4.3"}
+             com.amazonaws/aws-lambda-java-core             {:mvn/version "1.2.0"}
+
+             ;; Sub-dependency has MEDIUM rated-vulnerabilities
+             org.apache.maven.wagon/wagon-http              {:mvn/version "2.2"}
+
+             ;; Has HIGH severity vulnerabilities
+             com.fasterxml.jackson.core/jackson-databind    {:mvn/version "2.4.2"}
+             com.fasterxml.jackson.core/jackson-annotations {:mvn/version "2.4.0"}
+
+             org.slf4j/slf4j-api                            {:mvn/version "1.7.25"}}
+ :mvn/repos {"central" {:url "https://repo1.maven.org/maven2/"}
+             "clojars" {:url "https://repo.clojars.org/"}}}


### PR DESCRIPTION
While using the [new classpath argument](https://github.com/rm-hull/lein-nvd/pull/75) provides a way to avoid false positives/negatives _in the analyzed corpus_, it doesn't necessarily isolate the lein-nvd implementation itself from a target project's dependencies.

For example, if a given project declared an `apache-commons` dependency, that could influence the `nvd.task.check` program and accordingly reproduce an issue like https://github.com/rm-hull/lein-nvd/issues/11.

So I think the cleanest possible way of running lein-nvd is outside the targeted project, while passing that project's classpath as an argument.

I learned this while implementing https://github.com/rm-hull/lein-nvd/blob/4f21d3a355641f00089b0b4525a233e16350f63c/.github/integration_test.sh (which uses exactly that technique)