### PR TITLE
CLI: support passing a config-filename and a classpath

### DIFF
--- a/.github/example_nvd_suppressions.xml
+++ b/.github/example_nvd_suppressions.xml
@@ -1,0 +1,3 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<suppressions xmlns="https://jeremylong.github.io/DependencyCheck/dependency-suppression.1.3.xsd">
+</suppressions>

--- a/.github/example_nvd_suppressions.xml
+++ b/.github/example_nvd_suppressions.xml
@@ -1,3 +1,12 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <suppressions xmlns="https://jeremylong.github.io/DependencyCheck/dependency-suppression.1.3.xsd">
+  <!--
+
+You can verify that integration_test.sh would fail if uncommenting these contents:
+
+<suppress>
+  <cvssBelow>10</cvssBelow>
+</suppress>
+
+  -->
 </suppressions>

--- a/.github/integration_test.sh
+++ b/.github/integration_test.sh
@@ -1,6 +1,9 @@
 #!/usr/bin/env bash
 set -Euxo pipefail
 
+CONFIG_FILE="$PWD/.github/nvd-config.json"
+SUCCESS_REGEX="[1-9][0-9] vulnerabilities detected\. Severity: "
+
 original=$(pwd)
 
 lein install
@@ -16,7 +19,7 @@ if lein nvd check > example-lein-output; then
   exit 1
 fi
 
-if ! grep --silent "[1-9][0-9] vulnerabilities detected\. Severity: " example-lein-output; then
+if ! grep --silent "$SUCCESS_REGEX" example-lein-output; then
   echo "Should have found vulnerabilities!"
   exit 1
 fi
@@ -28,12 +31,12 @@ example_classpath="$(lein with-profile -user,-dev,-test classpath)"
 # cd to the root dir, so that one runs `defproject nvd-clojure` which is the most clean and realistic way to run `main`:
 cd .. || exit 1
 
-if lein with-profile -user,-dev run -m nvd.task.check "" "$example_classpath" > example-lein-output; then
+if lein with-profile -user,-dev run -m nvd.task.check "$CONFIG_FILE" "$example_classpath" > example-lein-output; then
   echo "Should have failed with non-zero code!"
   exit 1
 fi
 
-if ! grep --silent "[1-9][0-9] vulnerabilities detected\. Severity: " example-lein-output; then
+if ! grep --silent "$SUCCESS_REGEX" example-lein-output; then
   echo "Should have found vulnerabilities!"
   exit 1
 fi
@@ -47,12 +50,12 @@ example_classpath="$(clojure -Spath)"
 # cd to the root dir, so that one runs `defproject nvd-clojure` which is the most clean and realistic way to run `main`:
 cd .. || exit 1
 
-if clojure -m nvd.task.check "" "$example_classpath" > example-lein-output; then
+if clojure -m nvd.task.check "$CONFIG_FILE" "$example_classpath" > example-lein-output; then
   echo "Should have failed with non-zero code!"
   exit 1
 fi
 
-if ! grep --silent "[1-9][0-9] vulnerabilities detected\. Severity: " example-lein-output; then
+if ! grep --silent "$SUCCESS_REGEX" example-lein-output; then
   echo "Should have found vulnerabilities!"
   exit 1
 fi

--- a/.github/nvd-config.json
+++ b/.github/nvd-config.json
@@ -1,0 +1,1 @@
+{"nvd": {"suppression-file": ".github/example_nvd_suppressions.xml"}}

--- a/README.md
+++ b/README.md
@@ -180,7 +180,7 @@ lein run -m nvd.task.check "" "$(lein with-profile -user,-dev classpath)"
 clojure -m nvd.task.check "" "$(clojure -Spath)"
 ```
 
-...in both cases, an empty string is passed as the first argument, for backwards compatibility reasons.
+...in both cases, an empty string is passed as the first argument, for backwards compatibility reasons. You can also pass a filename instead, denoting a .json file with extra options.
 
 For extra isolation, it is recommended that you invoke `nvd.task.check` from _outside_ your project - e.g. from an empty project, a git clone of this very repo, or from $HOME (assuming you have lein-nvd as a dependency in your [user-wide Lein profile](https://github.com/technomancy/leiningen/blob/2586957f9d099ff11d50d312a6daf397c2a06fb1/doc/PROFILES.md)).
 

--- a/src/nvd/config.clj
+++ b/src/nvd/config.clj
@@ -69,7 +69,7 @@
    Settings$KEYS/ANALYZER_NEXUS_USES_PROXY [:analyzer :nexus-uses-proxy]})
 
 (defn app-name [project]
-  (let [name (get project :name "unknown")
+  (let [name (get project :name "stdin")
         group (get project :group name)]
     (if (= group name)
       name

--- a/test/nvd/config_test.clj
+++ b/test/nvd/config_test.clj
@@ -29,7 +29,7 @@
 (def dependency-check-version "6.1.6")
 
 (deftest check-app-name
-  (is (= "unknown" (app-name {:nome "hello-world" :version "0.0.1"})))
+  (is (= "stdin" (app-name {:nome "hello-world" :version "0.0.1"})))
   (is (= "hello-world" (app-name {:name "hello-world" :version "0.0.1"})))
   (is (= "hello-world" (app-name {:name "hello-world" :group "hello-world" :version "0.0.1"})))
   (is (= "fred/hello-world" (app-name {:name "hello-world" :group "fred" :version "0.0.1"}))))


### PR DESCRIPTION
By supporting both at the same time, one can have version-controlled config files (as opposed to dynamically generated temp files having an unstable `classpath` entry).

An important use case would be having a custom `suppression-file`.

I verified that this works locally in a real-world project, and also in lein-nvd itself by playing with integration_test.sh