### PR TITLE
CI: setup linting

### DIFF
--- a/.clj-kondo/config.edn
+++ b/.clj-kondo/config.edn
@@ -1,0 +1,1 @@
+{:lint-as {nvd.config/with-config clojure.core/let}}

--- a/.github/lint.sh
+++ b/.github/lint.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+set -Eeuxo pipefail
+
+# 1.- lint nvd-clojure:
+
+classpath="$(lein with-profile -user,+test classpath)"
+# populate a clj-kondo cache per https://github.com/clj-kondo/clj-kondo/tree/4f1252748b128da6ea23033f14b2bec8662dc5fd#project-setup :
+lein with-profile -user,+test,+clj-kondo run -m clj-kondo.main --lint "$classpath" --dependencies --parallel --copy-configs
+lein with-profile -user,+test,+clj-kondo run -m clj-kondo.main --lint src test
+lein eastwood
+
+# 2.- lint lein-nvd:
+
+cd plugin || exit 1
+lein eastwood

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -19,6 +19,7 @@ jobs:
         uses: snow-actions/eclint@v1.0.1
         with:
           args: 'check .* * src/**/*.clj test/**/*.clj'
+      - run: .github/lint.sh
       - name: Install leiningen
         uses: DeLaGuardo/setup-clojure@master
         with:
@@ -50,5 +51,5 @@ jobs:
         with:
           lein: 2.9.4
           cli: 1.10.1.693
-      - run: shellcheck .github/integration_test.sh
+      - run: shellcheck .github/*.sh
       - run: .github/integration_test.sh

--- a/plugin/project.clj
+++ b/plugin/project.clj
@@ -35,6 +35,7 @@
       :dependencies [
         [org.clojure/clojure "1.10.3"] ]
       :plugins [
+        [jonase/eastwood "0.4.3"]
         [lein-codox "0.10.7"]
         [lein-cloverage "1.1.1"]]}
     :ci {:pedantic? :abort}}

--- a/plugin/src/leiningen/nvd.clj
+++ b/plugin/src/leiningen/nvd.clj
@@ -28,9 +28,11 @@
    [leiningen.nvd.deps :refer [get-classpath]]
    [nvd.task.update-database]
    [nvd.task.purge-database]
-   [nvd.task.check]))
+   [nvd.task.check])
+  (:import
+   [java.io File]))
 
-(def temp-file (java.io.File/createTempFile ".lein-nvd_" ".json"))
+(def ^File temp-file (File/createTempFile ".lein-nvd_" ".json"))
 
 (defn nvd "
   Scans project dependencies, attempting to detect publicly disclosed

--- a/project.clj
+++ b/project.clj
@@ -36,7 +36,10 @@
         [lein-cljfmt "0.7.0"]
         [lein-codox "0.10.7"]
         [lein-cloverage "1.2.2"]
-        [lein-ancient "0.7.0"]]
+        [lein-ancient "0.7.0"]
+        [jonase/eastwood "0.4.3"]]
       :dependencies [
+        [clj-kondo "2021.04.23"]
         [commons-collections "20040616"]]}
-    :ci {:pedantic? :abort}})
+    :ci {:pedantic? :abort}
+    :clj-kondo {:dependencies [[clj-kondo "2021.04.23"]]}})

--- a/src/nvd/config.clj
+++ b/src/nvd/config.clj
@@ -22,12 +22,10 @@
 
 (ns nvd.config
   (:require
-   [clojure.string :as s]
    [clojure.java.io :as io]
    [clojure.data.json :as json])
   (:import
    [org.owasp.dependencycheck Engine]
-   [org.owasp.dependencycheck.data.nvdcve CveDB DatabaseProperties]
    [org.owasp.dependencycheck.utils Settings Settings$KEYS]))
 
 (def ^:private string-mappings

--- a/src/nvd/report.clj
+++ b/src/nvd/report.clj
@@ -25,12 +25,12 @@
    [clojure.string :as s]
    [clojure.java.io :as io]
    [clansi :refer [style]]
-   [table.core :refer [table]]
-   [nvd.config :as config])
+   [table.core :refer [table]])
   (:import
    [java.util Arrays]
    [org.owasp.dependencycheck Engine]
    [org.owasp.dependencycheck.dependency Dependency Vulnerability]
+   [org.owasp.dependencycheck.exception ExceptionCollection]
    [org.owasp.dependencycheck.reporting ReportGenerator]))
 
 (def default-output-dir "target/nvd")
@@ -44,7 +44,8 @@
         deps (Arrays/asList (.getDependencies engine))
         analyzers (.getAnalyzers engine)
         settings (.getSettings engine)
-        rg (ReportGenerator. title deps analyzers db-props settings)]
+        exception-collection (ExceptionCollection.)
+        rg (ReportGenerator. title deps analyzers db-props settings exception-collection)]
     (.write rg ^String output-dir ^String output-fmt)
     project))
 

--- a/test/nvd/config_test.clj
+++ b/test/nvd/config_test.clj
@@ -23,8 +23,8 @@
 (ns nvd.config-test
   (:require
    [clojure.java.io :as io]
-   [clojure.test :refer :all]
-   [nvd.config :refer :all]))
+   [clojure.test :refer [deftest is]]
+   [nvd.config :refer [app-name with-config]]))
 
 (def dependency-check-version "6.1.6")
 

--- a/test/nvd/task/check_test.clj
+++ b/test/nvd/task/check_test.clj
@@ -23,7 +23,7 @@
 (ns nvd.task.check-test
   (:require
    [clojure.java.io :as io]
-   [clojure.test :refer :all]
+   [clojure.test :refer [deftest is]]
    [nvd.task.update-database :as update-db]
    [nvd.task.check :as check])
   (:import

--- a/test/nvd/task/purge_database_test.clj
+++ b/test/nvd/task/purge_database_test.clj
@@ -23,7 +23,7 @@
 (ns nvd.task.purge-database-test
   (:require
    [clojure.java.io :as io]
-   [clojure.test :refer :all]
+   [clojure.test :refer [deftest is]]
    [nvd.task.purge-database :as purge]))
 
 (deftest check-purge-db


### PR DESCRIPTION
Because lein-nvd is a security-related tool, it seems a good idea to use every caution to ensure the project itself is bug-free. Therefore I thought of adding clj-kondo and Eastwood, which are complementary linters.

In this case Eastwood found some deprecations (java- and clojure-wise) + reflection warnings; clj-kondo found various unused symbols.