### PR TITLE
Release 5.1.0 (with #187)

### DIFF
--- a/.github/integration_test.sh
+++ b/.github/integration_test.sh
@@ -5,9 +5,17 @@ cd "${BASH_SOURCE%/*}/.." || exit 1
 
 export LEIN_JVM_OPTS="-Dclojure.main.report=stderr"
 PROJECT_DIR="$PWD"
-CONFIG_FILE="$PROJECT_DIR/.github/nvd-config.json"
-DOGFOODING_CONFIG_FILE="$PROJECT_DIR/.github/nvd-dogfooding-config.json"
-TOOLS_CONFIG_FILE="$PROJECT_DIR/.github/nvd-tool-config.json"
+
+CONFIG_FILE="$PROJECT_DIR/.github/nvd-config.edn"
+CONFIG_FILE_USING_DEFAULT_FILENAME="$PROJECT_DIR/nvd-clojure.edn"
+DOGFOODING_CONFIG_FILE="$PROJECT_DIR/.github/nvd-dogfooding-config.edn"
+TOOLS_CONFIG_FILE="$PROJECT_DIR/.github/nvd-tool-config.edn"
+
+JSON_CONFIG_FILE="$PROJECT_DIR/.github/nvd-config.json"
+JSON_DOGFOODING_CONFIG_FILE="$PROJECT_DIR/.github/nvd-dogfooding-config.json"
+JSON_TOOLS_CONFIG_FILE="$PROJECT_DIR/.github/nvd-tool-config.json"
+
+A_CUSTOM_CHANGE=":a-custom-change"
 SUCCESS_REGEX="[1-9][0-9] vulnerabilities detected\. Severity: "
 
 if ! lein with-profile -user,-dev,+ci install; then
@@ -18,9 +26,9 @@ if ! clojure -Ttools install nvd-clojure/nvd-clojure '{:mvn/version "RELEASE"}' 
   exit 1
 fi
 
-cd "$PROJECT_DIR/example" || exit 1
+# 1.- Exercise `main` program (EDN)
 
-# 1.- Exercise `main` program
+cd "$PROJECT_DIR/example" || exit 1
 
 example_classpath="$(lein with-profile -user,-dev,-test classpath)"
 
@@ -33,11 +41,69 @@ if lein with-profile -user,-dev,+ci run -m nvd.task.check "$CONFIG_FILE" "$examp
 fi
 
 if ! grep --silent "$SUCCESS_REGEX" example-lein-output; then
-  echo "Should have found vulnerabilities! (Step 1)"
+  echo "Should have found vulnerabilities! (Step 1 - EDN)"
   exit 1
 fi
 
-# 2.- Exercise `tools.deps` integration
+if grep --silent "$A_CUSTOM_CHANGE" example-lein-output; then
+  echo "$CONFIG_FILE and $CONFIG_FILE_USING_DEFAULT_FILENAME should have different contents!"
+  exit 1
+fi
+
+if grep --silent "$A_CUSTOM_CHANGE" "$CONFIG_FILE"; then
+  echo "$CONFIG_FILE and $CONFIG_FILE_USING_DEFAULT_FILENAME should have different contents!"
+  exit 1
+fi
+
+# 1.- Exercise `main` program (EDN; implicitly using the default filename)
+
+cd "$PROJECT_DIR/example" || exit 1
+
+example_classpath="$(lein with-profile -user,-dev,-test classpath)"
+
+# cd to the root dir, so that one runs `defproject nvd-clojure` which is the most clean and realistic way to run `main`:
+cd "$PROJECT_DIR" || exit 1
+
+if lein with-profile -user,-dev,+ci run -m nvd.task.check "" "$example_classpath" > example-lein-output 2>&1; then
+  echo "Should have failed with non-zero code!"
+  exit 1
+fi
+
+if ! grep --silent "$SUCCESS_REGEX" example-lein-output; then
+  echo "Should have found vulnerabilities! (Step 1 - EDN - default filename)"
+  exit 1
+fi
+
+if ! grep --silent "$A_CUSTOM_CHANGE" example-lein-output; then
+  echo "Passing an empty string as the config name should result in the config having the default filename being used!"
+  exit 1
+fi
+
+if ! grep --silent "$A_CUSTOM_CHANGE" "$CONFIG_FILE_USING_DEFAULT_FILENAME"; then
+  echo "Passing an empty string as the config name should not result in the config file being overriden!"
+  exit 1
+fi
+
+# 1.- Exercise `main` program (JSON)
+
+cd "$PROJECT_DIR/example" || exit 1
+
+example_classpath="$(lein with-profile -user,-dev,-test classpath)"
+
+# cd to the root dir, so that one runs `defproject nvd-clojure` which is the most clean and realistic way to run `main`:
+cd "$PROJECT_DIR" || exit 1
+
+if lein with-profile -user,-dev,+ci run -m nvd.task.check "$JSON_CONFIG_FILE" "$example_classpath" > example-lein-output; then
+  echo "Should have failed with non-zero code!"
+  exit 1
+fi
+
+if ! grep --silent "$SUCCESS_REGEX" example-lein-output; then
+  echo "Should have found vulnerabilities! (Step 1 - JSON)"
+  exit 1
+fi
+
+# 2.- Exercise `tools.deps` integration (EDN)
 
 cd "$PROJECT_DIR/example" || exit 1
 
@@ -52,11 +118,30 @@ if clojure -J-Dclojure.main.report=stderr -M -m nvd.task.check "$CONFIG_FILE" "$
 fi
 
 if ! grep --silent "$SUCCESS_REGEX" example-lein-output; then
-  echo "Should have found vulnerabilities! (Step 2)"
+  echo "Should have found vulnerabilities! (Step 2 - EDN)"
   exit 1
 fi
 
-# 3.- Exercise Clojure CLI Tools integration
+# 2.- Exercise `tools.deps` integration (JSON)
+
+cd "$PROJECT_DIR/example" || exit 1
+
+example_classpath="$(clojure -Spath)"
+
+# cd to the root dir, so that one runs `defproject nvd-clojure` which is the most clean and realistic way to run `main`:
+cd "$PROJECT_DIR" || exit 1
+
+if clojure -J-Dclojure.main.report=stderr -M -m nvd.task.check "$JSON_CONFIG_FILE" "$example_classpath" > example-lein-output; then
+  echo "Should have failed with non-zero code!"
+  exit 1
+fi
+
+if ! grep --silent "$SUCCESS_REGEX" example-lein-output; then
+  echo "Should have found vulnerabilities! (Step 2 - JSON)"
+  exit 1
+fi
+
+# 3.- Exercise Clojure CLI Tools integration (EDN)
 
 cd "$PROJECT_DIR/example" || exit 1
 
@@ -71,18 +156,48 @@ if clojure -J-Dclojure.main.report=stderr -Tnvd nvd.task/check :classpath \""$ex
 fi
 
 if ! grep --silent "$SUCCESS_REGEX" example-lein-output; then
-  echo "Should have found vulnerabilities! (Step 3)"
+  echo "Should have found vulnerabilities! (Step 3 - EDN)"
   exit 1
 fi
 
-# 4.- Dogfood the `nvd-clojure` project
+# 3.- Exercise Clojure CLI Tools integration (JSON)
+
+cd "$PROJECT_DIR/example" || exit 1
+
+example_classpath="$(clojure -Spath)"
+
+# cd to $HOME, to demonstrate that the Tool does not depend on a deps.edn file:
+cd || exit 1
+
+if clojure -J-Dclojure.main.report=stderr -Tnvd nvd.task/check :classpath \""$example_classpath\"" :config-filename \""$JSON_TOOLS_CONFIG_FILE\"" > example-lein-output; then
+  echo "Should have failed with non-zero code!"
+  exit 1
+fi
+
+if ! grep --silent "$SUCCESS_REGEX" example-lein-output; then
+  echo "Should have found vulnerabilities! (Step 3 - JSON)"
+  exit 1
+fi
+
+# 4.- Dogfood the `nvd-clojure` project (EDN)
 
 cd "$PROJECT_DIR" || exit 1
 
 own_classpath="$(lein with-profile -user,-dev,-test classpath)"
 
 if ! lein with-profile -user,-dev,+ci,+skip-self-check run -m nvd.task.check "$DOGFOODING_CONFIG_FILE" "$own_classpath"; then
-  echo "nvd-clojure did not pass dogfooding!"
+  echo "nvd-clojure did not pass dogfooding! (EDN)"
+  exit 1
+fi
+
+# 4.- Dogfood the `nvd-clojure` project (JSON)
+
+cd "$PROJECT_DIR" || exit 1
+
+own_classpath="$(lein with-profile -user,-dev,-test classpath)"
+
+if ! lein with-profile -user,-dev,+ci,+skip-self-check run -m nvd.task.check "$JSON_DOGFOODING_CONFIG_FILE" "$own_classpath"; then
+  echo "nvd-clojure did not pass dogfooding! (JSON)"
   exit 1
 fi
 

--- a/.github/nvd-config.edn
+++ b/.github/nvd-config.edn
@@ -1,0 +1,2 @@
+{:suppression-file ".github/example_nvd_suppressions.xml"
+ :analyzer {:ossindex-warn-only-on-remote-errors true}}

--- a/.github/nvd-dogfooding-config.edn
+++ b/.github/nvd-dogfooding-config.edn
@@ -1,0 +1,2 @@
+{:suppression-file ".github/dogfooding_suppressions.xml"
+ :analyzer {:ossindex-warn-only-on-remote-errors true}}

--- a/.github/nvd-tool-config.edn
+++ b/.github/nvd-tool-config.edn
@@ -1,0 +1,1 @@
+{:analyzer {:ossindex-warn-only-on-remote-errors true}}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## Changes from 2.13.0 to 3.0.0
+
+* Introduce .edn configuration format.
+  * .json files will remain working as-is indefinitely.
+  * If you wish to migrate to the .edn format, doing so is easy - please see [FAQ]().
+  * If you specify the blank string as the config file to be used, a sample .edn file with comments will be generated.
+
 ## Changes from 2.12.0 to 2.13.0
 
 * Update `dependency-check-core`.

--- a/nvd-clojure.edn
+++ b/nvd-clojure.edn
@@ -1,0 +1,4 @@
+{ ;; This file is part of the integration test suite.
+ :suppression-file ".github/example_nvd_suppressions.xml"
+ :analyzer {:ossindex-warn-only-on-remote-errors true}
+ :a-custom-change 42}

--- a/resources/nvd_clojure/default_config_content.edn
+++ b/resources/nvd_clojure/default_config_content.edn
@@ -1,0 +1,14 @@
+;; This is an automatically generated config file by nvd-clojure.
+;; Feel free to tweak it and remove any comment.
+
+{#_:suppression-file
+ ;; Create and use this file in order to silence false positives.
+ ;; Reference: https://jeremylong.github.io/DependencyCheck/general/suppression.html
+ #_"nvd_suppressions.xml"
+
+ #_:analyzer ;; Analyzer options, which are mostly advanced/internal
+ #_{:ossindex-warn-only-on-remote-errors
+     ;; Occasionally necessary for not making HTTP 500 errors from OSS Index (one of the multiple analyzers internally used)
+     ;; a reason for execution to fail.
+     ;; Please only enable this carefully since it can mean false negatives.
+    true}}

--- a/test/nvd/config_test.clj
+++ b/test/nvd/config_test.clj
@@ -1,31 +1,11 @@
-;; The MIT License (MIT)
-;;
-;; Copyright (c) 2016- Richard Hull
-;;
-;; Permission is hereby granted, free of charge, to any person obtaining a copy
-;; of this software and associated documentation files (the "Software"), to deal
-;; in the Software without restriction, including without limitation the rights
-;; to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-;; copies of the Software, and to permit persons to whom the Software is
-;; furnished to do so, subject to the following conditions:
-;;
-;; The above copyright notice and this permission notice shall be included in all
-;; copies or substantial portions of the Software.
-;;
-;; THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-;; IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-;; FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-;; AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-;; LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-;; OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-;; SOFTWARE.
-
 (ns nvd.config-test
   (:require
    [clojure.java.io :as io]
    [clojure.string :as string]
-   [clojure.test :refer [deftest is]]
-   [nvd.config :refer [app-name with-config]]))
+   [clojure.test :refer [deftest is testing]]
+   [nvd.config :as sut])
+  (:import
+   (java.util UUID)))
 
 (def dependency-check-version
   (let [dependencies (-> "project.clj" io/file slurp read-string (nth 10))
@@ -39,13 +19,13 @@
     found))
 
 (deftest check-app-name
-  (is (= "stdin" (app-name {:nome "hello-world" :version "0.0.1"})))
-  (is (= "hello-world" (app-name {:name "hello-world" :version "0.0.1"})))
-  (is (= "hello-world" (app-name {:name "hello-world" :group "hello-world" :version "0.0.1"})))
-  (is (= "fred/hello-world" (app-name {:name "hello-world" :group "fred" :version "0.0.1"}))))
+  (is (= "stdin" (sut/app-name {:nome "hello-world" :version "0.0.1"})))
+  (is (= "hello-world" (sut/app-name {:name "hello-world" :version "0.0.1"})))
+  (is (= "hello-world" (sut/app-name {:name "hello-world" :group "hello-world" :version "0.0.1"})))
+  (is (= "fred/hello-world" (sut/app-name {:name "hello-world" :group "fred" :version "0.0.1"}))))
 
 (deftest check-with-config
-  (with-config [project "test/resources/opts.json"]
+  (sut/with-config [project "test/resources/opts.json"]
     (let [path (-> project (get-in [:nvd :data-directory]) io/file .getAbsolutePath)
           suffix-1 (-> dependency-check-version
                        (string/split #"\.")
@@ -72,7 +52,39 @@
     (is (false? (get-in project [:nvd :analyzer :assembly-enabled])))
     (is (true? (get-in project [:nvd :analyzer :cmake-enabled])))
     (is (not (nil? (get-in project [:engine]))))
-    (is (= (get-in project [:title]) "barry-fungus/test-project 1.0.3-SNAPSHOT"))
-    (is (= (get-in project [:config-file]) "test/resources/opts.json"))
-    (is (= (get-in project [:cmd-args]) "12 -t hello"))
-    (is (= (get-in project [:classpath]) ["file1.jar", "file2.jar"]))))
+    (is (= (get project :title) "barry-fungus/test-project 1.0.3-SNAPSHOT"))
+    (is (= (get project :config-file) "test/resources/opts.json"))
+    (is (= (get project :cmd-args) "12 -t hello"))
+    (is (= (get project :classpath) ["file1.jar", "file2.jar"]))))
+
+(deftest maybe-create-edn-file!
+  (assert (not (-> sut/default-edn-config-filename io/file .exists)))
+
+  (try
+    (testing "Does not overwrite a config file with a name different from the default filename"
+      (let [other-filename (-> (UUID/randomUUID) (str ".edn"))
+            content (-> (UUID/randomUUID) str)]
+        (try
+          (spit other-filename content)
+          (sut/maybe-create-edn-file! other-filename)
+          (is (= content
+                 (slurp other-filename)))
+          (finally
+            (-> other-filename io/file .delete)))))
+
+    (testing "Does not overwrite a config file that happened to have the default filename"
+      (let [content (-> (UUID/randomUUID) str)]
+        (spit sut/default-edn-config-filename content)
+        (sut/maybe-create-edn-file! sut/default-edn-config-filename)
+        (is (= content
+               (slurp sut/default-edn-config-filename)))))
+
+    (-> sut/default-edn-config-filename io/file .delete)
+
+    (testing "Writes the default content when the file didn't exist"
+      (sut/maybe-create-edn-file! sut/default-edn-config-filename)
+      (is (= @sut/default-config-content
+             (slurp sut/default-edn-config-filename))))
+
+    (finally
+      (-> sut/default-edn-config-filename io/file .delete))))


### PR DESCRIPTION
### Don't fail when no vulnerabilities were detected

This allows setting fail-threshold to -1 which will result in a failure in case only vulnerabilities
with a score of 0 were detected. This is a pertty common occurrence these days as the NVD struggles
to keep up with assigning scores to newly reported CVEs in a timely manner.

### Update README to mention fail-threshold -1

While at it, make wording of fail-threshold doc less ambiguous.

Co-authored-by: Toby Crawley <toby@tcrawley.org>

### Prep for 5.1.0 release